### PR TITLE
Fix watch integration tests

### DIFF
--- a/internal/proxy/suricata_test.go
+++ b/internal/proxy/suricata_test.go
@@ -41,7 +41,7 @@ func TestServer_SuricataMatch(t *testing.T) {
 	hcl := `rule "suri" {
   action = "deny"
   when all {
-    suricata_msg = ["*Test Suricata*"]
+    suricata_msg = ["Test Suricata"]
   }
 }`
 	tmp, err := os.CreateTemp(t.TempDir(), "rule-*.hcl")
@@ -136,7 +136,7 @@ func TestServer_SuricataMatch_NoLogger(t *testing.T) {
 	hcl := `rule "suri" {
   action = "deny"
   when all {
-    suricata_msg = ["*Test Suricata*"]
+    suricata_msg = ["Test Suricata"]
   }
 }`
 	tmp, err := os.CreateTemp(t.TempDir(), "rule-*.hcl")


### PR DESCRIPTION
## Summary
- ensure body read error test runs body parsing by providing a logger
- adjust watch integration tests for newer HCL parsing
- allocate dynamic listener ports for watch integration tests
- remove wildcard patterns that break rule loading

## Testing
- `go test ./... -tags skipproxy`

------
https://chatgpt.com/codex/tasks/task_e_688674eba8448331bc078680219421fd