### PR TITLE
Allow explicit false for upstream TLS verification

### DIFF
--- a/cmd/finch/configwatcher.go
+++ b/cmd/finch/configwatcher.go
@@ -169,8 +169,12 @@ func watchConfig(ctx context.Context, path string, rt *runtimeState, svc **galah
 				if caFile == "" && cfg.Defaults != nil {
 					caFile = cfg.Defaults.UpstreamCAFile
 				}
-				if !skipVerify && cfg.Defaults != nil {
+				if skipVerify == nil && cfg.Defaults != nil {
 					skipVerify = cfg.Defaults.UpstreamSkipTLSVerify
+				}
+				skip := false
+				if skipVerify != nil {
+					skip = *skipVerify
 				}
 				if l.Bind != srv.ListenAddr ||
 					l.Upstream != srv.UpstreamURL.String() ||
@@ -178,7 +182,7 @@ func watchConfig(ctx context.Context, path string, rt *runtimeState, svc **galah
 					certFile != srv.CertFile ||
 					keyFile != srv.KeyFile ||
 					caFile != srv.UpstreamCAFile ||
-					skipVerify != srv.UpstreamSkipVerify {
+					skip != srv.UpstreamSkipVerify {
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					_ = srv.Shutdown(ctx)
 					cancel()

--- a/cmd/finch/runtime.go
+++ b/cmd/finch/runtime.go
@@ -196,7 +196,17 @@ func (rt *runtimeState) addListener(l config.ListenerConfig, cfg *config.Config,
 		certFile = l.TLS.Cert
 		keyFile = l.TLS.Key
 	}
-	svr, err := proxy.New(l.ID, l.Bind, l.Upstream, certFile, keyFile, lgr, localEng, globalEng, suriSet, hub, rt.galahSvc, l.UpstreamCAFile, l.UpstreamSkipTLSVerify)
+	caFile := l.UpstreamCAFile
+	skip := false
+	if l.UpstreamSkipTLSVerify != nil {
+		skip = *l.UpstreamSkipTLSVerify
+	} else if cfg.Defaults != nil && cfg.Defaults.UpstreamSkipTLSVerify != nil {
+		skip = *cfg.Defaults.UpstreamSkipTLSVerify
+	}
+	if caFile == "" && cfg.Defaults != nil {
+		caFile = cfg.Defaults.UpstreamCAFile
+	}
+	svr, err := proxy.New(l.ID, l.Bind, l.Upstream, certFile, keyFile, lgr, localEng, globalEng, suriSet, hub, rt.galahSvc, caFile, skip)
 	if err != nil {
 		return nil, fmt.Errorf("server %s: %w", l.ID, err)
 	}

--- a/cmd/finch/runtime_test.go
+++ b/cmd/finch/runtime_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0x4D31/finch/internal/config"
+)
+
+func TestAddListenerSkipVerifyOverride(t *testing.T) {
+	tmp := t.TempDir()
+	log := filepath.Join(tmp, "log")
+	rt := &runtimeState{
+		loader:   NewLoader(""),
+		loggers:  make(map[string]*logRef),
+		logPaths: make(map[string]string),
+		pf:       parsedFlags{},
+	}
+	tru := true
+	fal := false
+	cfg := &config.Config{Defaults: &config.Defaults{AccessLog: log, UpstreamSkipTLSVerify: &tru}}
+	l := config.ListenerConfig{
+		ID:                    "a",
+		Bind:                  "127.0.0.1:0",
+		Upstream:              "http://example.com",
+		AccessLog:             "",
+		UpstreamSkipTLSVerify: &fal,
+	}
+	srv, err := rt.addListener(l, cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("addListener: %v", err)
+	}
+	if srv.UpstreamSkipVerify {
+		t.Fatalf("expected skip verify false, got true")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	_ = srv.Shutdown(ctx)
+	cancel()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,7 @@ type Defaults struct {
 	DefaultAction         string `hcl:"default_action,optional" json:"default_action,omitempty"`
 	ProxyCacheSize        int    `hcl:"proxy_cache_size,optional" json:"proxy_cache_size,omitempty"`
 	UpstreamCAFile        string `hcl:"upstream_ca_file,optional" json:"upstream_ca_file,omitempty"`
-	UpstreamSkipTLSVerify bool   `hcl:"upstream_skip_tls_verify,optional" json:"upstream_skip_tls_verify,omitempty"`
+	UpstreamSkipTLSVerify *bool  `hcl:"upstream_skip_tls_verify,optional" json:"upstream_skip_tls_verify,omitempty"`
 }
 
 // ListenerConfig defines a single listener instance.
@@ -66,7 +66,7 @@ type ListenerConfig struct {
 	AccessLog             string     `hcl:"access_log,optional" json:"access_log,omitempty"`
 	TLS                   *TLSConfig `hcl:"tls,block" json:"tls,omitempty"`
 	UpstreamCAFile        string     `hcl:"upstream_ca_file,optional" json:"upstream_ca_file,omitempty"`
-	UpstreamSkipTLSVerify bool       `hcl:"upstream_skip_tls_verify,optional" json:"upstream_skip_tls_verify,omitempty"`
+	UpstreamSkipTLSVerify *bool      `hcl:"upstream_skip_tls_verify,optional" json:"upstream_skip_tls_verify,omitempty"`
 }
 
 // TLSConfig holds optional TLS certificate paths.


### PR DESCRIPTION
## Summary
- represent upstream_skip_tls_verify as *bool to distinguish unset from false
- merge defaults only when listener leaves upstream_skip_tls_verify unset
- add regression tests for skip-tls-verify inheritance

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894781549cc83318a8a95c7a564dadc